### PR TITLE
Add unique items that are always eth to the eth grail

### DIFF
--- a/client/src/common/seeds/EthGrailSeedData.ts
+++ b/client/src/common/seeds/EthGrailSeedData.ts
@@ -215,7 +215,8 @@ export const ethGrailSeedData: IEthGrailData = {
         elite: {
           Hellslayer: {},
           "Messerschmidt's Reaver": {},
-          "Executioner's Justice": {}
+          "Executioner's Justice": {},
+          "Ethereal Edge": {}
         }
       },
       dagger: {
@@ -232,7 +233,8 @@ export const ethGrailSeedData: IEthGrailData = {
           Stormspike: {}
         },
         elite: {
-          Fleshripper: {}
+          Fleshripper: {},
+          Ghostflame: {}
         }
       },
       "clubs (1-h)": {
@@ -429,7 +431,8 @@ export const ethGrailSeedData: IEthGrailData = {
           Lacerator: {},
           Warshrike: {},
           "Demon's Arch": {},
-          "Gargoyle's Bite": {}
+          "Gargoyle's Bite": {},
+          "Wraith Flight": {}
         }
       }
     },
@@ -444,7 +447,8 @@ export const ethGrailSeedData: IEthGrailData = {
         assasin: {
           "Bartuc's Cut-Throat": {},
           "Firelizard's Talons": {},
-          "Jade Talon": {}
+          "Jade Talon": {},
+          "Shadow Killer": {}
         },
         barbarian: {
           "Arreat's Face": {},


### PR DESCRIPTION
Adds Ethereal Edge, Ghostflame, Wraith Flight, and Shadow Killer to the eth grail. They always spawn eth, but they should still be included.