### PR TITLE
Increase payload limit to 1mb

### DIFF
--- a/server/src/initializers/AppInitializer.ts
+++ b/server/src/initializers/AppInitializer.ts
@@ -8,8 +8,8 @@ import { GrailController } from "../controllers/GrailController";
 import { ItemsController } from "../controllers/ItemsController";
 
 function initializeExpressServer(express: expressServer.Express): void {
-  express.use(bodyParser.urlencoded({ extended: true }));
-  express.use(bodyParser.json());
+  express.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }));
+  express.use(bodyParser.json({ limit: '1mb' }));
   express.use(cors());
 }
 


### PR DESCRIPTION
Default limit is 100kb which is fairly easy to exceed if notes are added to a lot of items. With just all keys being present for each item (`wasFound`, `isPerfect`, `note`), even with empty values, the json is about 50kb.

1mb should be enough for most purposes, but let me know if you'd like a different value.