### PR TITLE
feat: add ability to toggle dark theme

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,10 +12,10 @@ import { PartyHome } from "./areas/party/home/PartyHome";
 import CssBaseline from "@material-ui/core/CssBaseline";
 import { MuiThemeProvider } from "@material-ui/core/styles";
 
-import { defaultTheme, IAppTheme, AppThemeContext } from "./AppThemeContext";
+import { AppThemeContext, IAppTheme, getDefaultTheme } from "./AppThemeContext";
 
 export const App: FC = () => {
-  const [appTheme, setAppTheme] = useState<IAppTheme>(defaultTheme);
+  const [appTheme, setAppTheme] = useState<IAppTheme>(getDefaultTheme());
 
   return (
     <AppThemeContext.Provider value={{ appTheme, setAppTheme: handleSetTheme }}>
@@ -58,7 +58,7 @@ export const App: FC = () => {
   );
 
   function handleSetTheme(appTheme?: IAppTheme) {
-    setAppTheme(appTheme || defaultTheme);
+    setAppTheme(appTheme || getDefaultTheme());
   }
 };
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { FC, useState } from "react";
+import { FC, useState, useMemo } from "react";
 import Typography from "@material-ui/core/Typography/Typography";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 import { Home } from "./areas/home/Home";
@@ -11,22 +11,40 @@ import { Party } from "./areas/party/Party";
 import { PartyHome } from "./areas/party/home/PartyHome";
 import CssBaseline from "@material-ui/core/CssBaseline";
 import { MuiThemeProvider } from "@material-ui/core/styles";
+import { Theme, createMuiTheme } from "@material-ui/core";
+import { AppThemeContext, IAppTheme, defaultTheme } from "./AppThemeContext";
+import { PaletteOptions } from "@material-ui/core/styles/createPalette";
+import { LocalStorageHandler } from "./common/utils/LocalStorageHandler";
 
-import { AppThemeContext, IAppTheme, getDefaultTheme } from "./AppThemeContext";
+interface IBuiltAppTheme {
+  theme: Theme;
+  title: string;
+}
+
+const darkThemeStorageHandler = new LocalStorageHandler<boolean>(
+  `is-dark-theme`
+);
 
 export const App: FC = () => {
-  const [appTheme, setAppTheme] = useState<IAppTheme>(getDefaultTheme());
+  const [theme, setTheme] = useState<IAppTheme>(defaultTheme);
+  const builtTheme = useMemo(() => buildTheme(theme), [theme]);
 
   return (
-    <AppThemeContext.Provider value={{ appTheme, setAppTheme: handleSetTheme }}>
-      <MuiThemeProvider theme={appTheme.theme}>
-        <ThemeProvider theme={appTheme.theme}>
+    <AppThemeContext.Provider
+      value={{
+        appTheme: builtTheme,
+        setAppTheme: handleSetTheme,
+        toggleDarkTheme: handleToggleDarkTheme
+      }}
+    >
+      <MuiThemeProvider theme={builtTheme.theme}>
+        <ThemeProvider theme={builtTheme.theme}>
           <>
             <CssBaseline />
             <BrowserRouter>
               <RootContainer>
                 <HeaderContainer>
-                  <Typography variant="h5">{appTheme.title}</Typography>
+                  <Typography variant="h5">{builtTheme.title}</Typography>
                 </HeaderContainer>
                 <GithubRibbon url="https://github.com/Nasicus/d2-holy-grail" />
                 <ContentContainer>
@@ -57,10 +75,36 @@ export const App: FC = () => {
     </AppThemeContext.Provider>
   );
 
-  function handleSetTheme(appTheme?: IAppTheme) {
-    setAppTheme(appTheme || getDefaultTheme());
+  function handleSetTheme(newTheme?: IAppTheme) {
+    if (!newTheme) {
+      newTheme = defaultTheme;
+    }
+
+    setTheme({ ...newTheme });
+  }
+
+  function handleToggleDarkTheme() {
+    darkThemeStorageHandler.setValue(!isDarkThemeEnabled());
+    handleSetTheme(theme);
+  }
+
+  function buildTheme(newTheme: IAppTheme): IBuiltAppTheme {
+    return {
+      title: newTheme.title,
+      theme: createMuiTheme({
+        ...newTheme.theme,
+        palette: {
+          ...newTheme.theme.palette,
+          ...(isDarkThemeEnabled() && ({ type: "dark" } as PaletteOptions))
+        }
+      })
+    };
   }
 };
+
+function isDarkThemeEnabled() {
+  return darkThemeStorageHandler.getValue() === true;
+}
 
 const RootContainer = styled.div`
   font-family: ${p => p.theme.typography.fontFamily};

--- a/client/src/AppThemeContext.tsx
+++ b/client/src/AppThemeContext.tsx
@@ -12,12 +12,34 @@ export interface IAppTheme {
   title: string;
 }
 
+let darkThemeEnabled = false;
+
+export function toggleDarkThemeEnabled() {
+  darkThemeEnabled = !darkThemeEnabled;
+}
+
+export function darkThemeIsEnabled() {
+  return darkThemeEnabled;
+}
+
 export const defaultTheme: IAppTheme = {
   theme: createMuiTheme({
     typography: {},
     palette: {
       primary: purple,
       secondary: green
+    }
+  }),
+  title: "Diablo II - Holy Grail"
+};
+
+export const defaultThemeDark: IAppTheme = {
+  theme: createMuiTheme({
+    typography: {},
+    palette: {
+      primary: purple,
+      secondary: green,
+      type: "dark"
     }
   }),
   title: "Diablo II - Holy Grail"
@@ -34,6 +56,18 @@ export const ethTheme: IAppTheme = {
   title: "Diablo II - Eth Grail"
 };
 
+export const ethThemeDark: IAppTheme = {
+  theme: createMuiTheme({
+    typography: {},
+    palette: {
+      primary: brown,
+      secondary: grey,
+      type: "dark"
+    }
+  }),
+  title: "Diablo II - Eth Grail"
+};
+
 export const runewordTheme: IAppTheme = {
   theme: createMuiTheme({
     typography: {},
@@ -45,12 +79,36 @@ export const runewordTheme: IAppTheme = {
   title: "Diablo II - Runeword Grail"
 };
 
+export const runewordThemeDark: IAppTheme = {
+  theme: createMuiTheme({
+    typography: {},
+    palette: {
+      primary: grey,
+      secondary: brown,
+      type: "dark"
+    }
+  }),
+  title: "Diablo II - Runeword Grail"
+};
+
 export const partyTheme: IAppTheme = {
   theme: createMuiTheme({
     typography: {},
     palette: {
       primary: blue,
       secondary: grey
+    }
+  }),
+  title: "Diablo II - Holy Grail Party"
+};
+
+export const partyThemeDark: IAppTheme = {
+  theme: createMuiTheme({
+    typography: {},
+    palette: {
+      primary: blue,
+      secondary: grey,
+      type: "dark"
     }
   }),
   title: "Diablo II - Holy Grail Party"

--- a/client/src/AppThemeContext.tsx
+++ b/client/src/AppThemeContext.tsx
@@ -1,73 +1,58 @@
 import { createContext } from "react";
-import { Theme, createMuiTheme } from "@material-ui/core";
 import { purple, green, brown, grey, blue } from "@material-ui/core/colors";
+import { ThemeOptions } from "@material-ui/core/styles/createMuiTheme";
 
 export const AppThemeContext = createContext<{
   appTheme: IAppTheme;
   setAppTheme: (theme?: IAppTheme) => any;
+  toggleDarkTheme: () => unknown;
 }>(null);
 
 export interface IAppTheme {
-  theme: Theme;
+  theme: ThemeOptions;
   title: string;
 }
 
-export function darkThemeIsEnabled(): boolean {
-  return localStorage.getItem("d2-holy-grail-useDarkTheme") === "true";
-}
+export const defaultTheme: IAppTheme = {
+  theme: {
+    typography: {},
+    palette: {
+      primary: purple,
+      secondary: green
+    }
+  },
+  title: "Diablo II - Holy Grail"
+};
 
-export function getDefaultTheme(): IAppTheme {
-  return {
-    theme: createMuiTheme({
-      typography: {},
-      palette: {
-        primary: purple,
-        secondary: green,
-        type: darkThemeIsEnabled() ? "dark" : "light"
-      }
-    }),
-    title: "Diablo II - Holy Grail"
-  };
-}
+export const ethTheme: IAppTheme = {
+  theme: {
+    typography: {},
+    palette: {
+      primary: brown,
+      secondary: grey
+    }
+  },
+  title: "Diablo II - Eth Grail"
+};
 
-export function getEthTheme(): IAppTheme {
-  return {
-    theme: createMuiTheme({
-      typography: {},
-      palette: {
-        primary: brown,
-        secondary: grey,
-        type: darkThemeIsEnabled() ? "dark" : "light"
-      }
-    }),
-    title: "Diablo II - Eth Grail"
-  };
-}
+export const runewordTheme: IAppTheme = {
+  theme: {
+    typography: {},
+    palette: {
+      primary: grey,
+      secondary: brown
+    }
+  },
+  title: "Diablo II - Runeword Grail"
+};
 
-export function getRunewordTheme(): IAppTheme {
-  return {
-    theme: createMuiTheme({
-      typography: {},
-      palette: {
-        primary: grey,
-        secondary: brown,
-        type: darkThemeIsEnabled() ? "dark" : "light"
-      }
-    }),
-    title: "Diablo II - Runeword Grail"
-  };
-}
-
-export function getPartyTheme(): IAppTheme {
-  return {
-    theme: createMuiTheme({
-      typography: {},
-      palette: {
-        primary: blue,
-        secondary: grey,
-        type: darkThemeIsEnabled() ? "dark" : "light"
-      }
-    }),
-    title: "Diablo II - Holy Grail Party"
-  };
-}
+export const partyTheme: IAppTheme = {
+  theme: {
+    typography: {},
+    palette: {
+      primary: blue,
+      secondary: grey
+    }
+  },
+  title: "Diablo II - Holy Grail Party"
+};

--- a/client/src/AppThemeContext.tsx
+++ b/client/src/AppThemeContext.tsx
@@ -12,104 +12,62 @@ export interface IAppTheme {
   title: string;
 }
 
-let darkThemeEnabled = false;
-
-export function toggleDarkThemeEnabled() {
-  darkThemeEnabled = !darkThemeEnabled;
+export function darkThemeIsEnabled(): boolean {
+  return localStorage.getItem("d2-holy-grail-useDarkTheme") === "true";
 }
 
-export function darkThemeIsEnabled() {
-  return darkThemeEnabled;
+export function getDefaultTheme(): IAppTheme {
+  return {
+    theme: createMuiTheme({
+      typography: {},
+      palette: {
+        primary: purple,
+        secondary: green,
+        type: darkThemeIsEnabled() ? "dark" : "light"
+      }
+    }),
+    title: "Diablo II - Holy Grail"
+  };
 }
 
-export const defaultTheme: IAppTheme = {
-  theme: createMuiTheme({
-    typography: {},
-    palette: {
-      primary: purple,
-      secondary: green
-    }
-  }),
-  title: "Diablo II - Holy Grail"
-};
+export function getEthTheme(): IAppTheme {
+  return {
+    theme: createMuiTheme({
+      typography: {},
+      palette: {
+        primary: brown,
+        secondary: grey,
+        type: darkThemeIsEnabled() ? "dark" : "light"
+      }
+    }),
+    title: "Diablo II - Eth Grail"
+  };
+}
 
-export const defaultThemeDark: IAppTheme = {
-  theme: createMuiTheme({
-    typography: {},
-    palette: {
-      primary: purple,
-      secondary: green,
-      type: "dark"
-    }
-  }),
-  title: "Diablo II - Holy Grail"
-};
+export function getRunewordTheme(): IAppTheme {
+  return {
+    theme: createMuiTheme({
+      typography: {},
+      palette: {
+        primary: grey,
+        secondary: brown,
+        type: darkThemeIsEnabled() ? "dark" : "light"
+      }
+    }),
+    title: "Diablo II - Runeword Grail"
+  };
+}
 
-export const ethTheme: IAppTheme = {
-  theme: createMuiTheme({
-    typography: {},
-    palette: {
-      primary: brown,
-      secondary: grey
-    }
-  }),
-  title: "Diablo II - Eth Grail"
-};
-
-export const ethThemeDark: IAppTheme = {
-  theme: createMuiTheme({
-    typography: {},
-    palette: {
-      primary: brown,
-      secondary: grey,
-      type: "dark"
-    }
-  }),
-  title: "Diablo II - Eth Grail"
-};
-
-export const runewordTheme: IAppTheme = {
-  theme: createMuiTheme({
-    typography: {},
-    palette: {
-      primary: grey,
-      secondary: brown
-    }
-  }),
-  title: "Diablo II - Runeword Grail"
-};
-
-export const runewordThemeDark: IAppTheme = {
-  theme: createMuiTheme({
-    typography: {},
-    palette: {
-      primary: grey,
-      secondary: brown,
-      type: "dark"
-    }
-  }),
-  title: "Diablo II - Runeword Grail"
-};
-
-export const partyTheme: IAppTheme = {
-  theme: createMuiTheme({
-    typography: {},
-    palette: {
-      primary: blue,
-      secondary: grey
-    }
-  }),
-  title: "Diablo II - Holy Grail Party"
-};
-
-export const partyThemeDark: IAppTheme = {
-  theme: createMuiTheme({
-    typography: {},
-    palette: {
-      primary: blue,
-      secondary: grey,
-      type: "dark"
-    }
-  }),
-  title: "Diablo II - Holy Grail Party"
-};
+export function getPartyTheme(): IAppTheme {
+  return {
+    theme: createMuiTheme({
+      typography: {},
+      palette: {
+        primary: blue,
+        secondary: grey,
+        type: darkThemeIsEnabled() ? "dark" : "light"
+      }
+    }),
+    title: "Diablo II - Holy Grail Party"
+  };
+}

--- a/client/src/areas/grail/GrailArea.tsx
+++ b/client/src/areas/grail/GrailArea.tsx
@@ -27,15 +27,10 @@ import { IGrailAreaRouterParams } from "../../RouteManager";
 import { GrailVersionMigrator } from "./migrations/GrailVersionMigrator";
 import {
   AppThemeContext,
-  defaultTheme,
-  defaultThemeDark,
-  ethTheme,
-  ethThemeDark,
   IAppTheme,
-  runewordTheme,
-  runewordThemeDark,
-  toggleDarkThemeEnabled,
-  darkThemeIsEnabled
+  darkThemeIsEnabled,
+  getEthTheme,
+  getRunewordTheme
 } from "../../AppThemeContext";
 import { ButtonWithProgress } from "../../common/components/ButtonWithProgress";
 
@@ -185,33 +180,25 @@ const GrailAreaInternal: FC<Props> = props => {
 
   function setThemeAndTitle() {
     let theme: IAppTheme = null;
-
-    let defaultThemeToSet = defaultTheme;
-    let ethThemeToSet = ethTheme;
-    let runewordThemeToSet = runewordTheme;
-
-    if (darkThemeIsEnabled()) {
-      defaultThemeToSet = defaultThemeDark;
-      ethThemeToSet = ethThemeDark;
-      runewordThemeToSet = runewordThemeDark;
-    }
-
     switch (grailMode) {
       case GrailMode.Eth:
-        theme = ethThemeToSet;
+        theme = getEthTheme();
         break;
       case GrailMode.Runeword:
-        theme = runewordThemeToSet;
+        theme = getRunewordTheme();
         break;
       default:
-        theme = defaultThemeToSet;
+        break;
     }
 
     setAppTheme(theme);
   }
 
   function toggleDarkTheme() {
-    toggleDarkThemeEnabled();
+    localStorage.setItem(
+      "d2-holy-grail-useDarkTheme",
+      (!darkThemeIsEnabled()).toString()
+    );
     setThemeAndTitle();
   }
 

--- a/client/src/areas/grail/GrailArea.tsx
+++ b/client/src/areas/grail/GrailArea.tsx
@@ -28,9 +28,8 @@ import { GrailVersionMigrator } from "./migrations/GrailVersionMigrator";
 import {
   AppThemeContext,
   IAppTheme,
-  darkThemeIsEnabled,
-  getEthTheme,
-  getRunewordTheme
+  ethTheme,
+  runewordTheme
 } from "../../AppThemeContext";
 import { ButtonWithProgress } from "../../common/components/ButtonWithProgress";
 
@@ -46,7 +45,7 @@ interface IGrailAreaState {
 
 const GrailAreaInternal: FC<Props> = props => {
   const [state, setState] = useState<IGrailAreaState>({ loading: true });
-  const { setAppTheme } = useContext(AppThemeContext);
+  const { setAppTheme, toggleDarkTheme } = useContext(AppThemeContext);
 
   const grailMode = getGrailModeFromRouteParams(props);
 
@@ -182,24 +181,16 @@ const GrailAreaInternal: FC<Props> = props => {
     let theme: IAppTheme = null;
     switch (grailMode) {
       case GrailMode.Eth:
-        theme = getEthTheme();
+        theme = ethTheme;
         break;
       case GrailMode.Runeword:
-        theme = getRunewordTheme();
+        theme = runewordTheme;
         break;
       default:
         break;
     }
 
     setAppTheme(theme);
-  }
-
-  function toggleDarkTheme() {
-    localStorage.setItem(
-      "d2-holy-grail-useDarkTheme",
-      (!darkThemeIsEnabled()).toString()
-    );
-    setThemeAndTitle();
   }
 
   function onFilterResult(result: IFilterResult) {

--- a/client/src/areas/grail/GrailArea.tsx
+++ b/client/src/areas/grail/GrailArea.tsx
@@ -27,10 +27,17 @@ import { IGrailAreaRouterParams } from "../../RouteManager";
 import { GrailVersionMigrator } from "./migrations/GrailVersionMigrator";
 import {
   AppThemeContext,
+  defaultTheme,
+  defaultThemeDark,
   ethTheme,
+  ethThemeDark,
   IAppTheme,
-  runewordTheme
+  runewordTheme,
+  runewordThemeDark,
+  toggleDarkThemeEnabled,
+  darkThemeIsEnabled
 } from "../../AppThemeContext";
+import { ButtonWithProgress } from "../../common/components/ButtonWithProgress";
 
 type Props = RouteComponentProps<IGrailAreaRouterParams>;
 
@@ -128,6 +135,11 @@ const GrailAreaInternal: FC<Props> = props => {
         <ButtonRow>
           <GrailTypeToggler grailMode={GrailManager.current.grailMode} />
         </ButtonRow>
+        <ButtonWithProgress
+          onClick={() => toggleDarkTheme()}
+          text="Toggle dark mode"
+          firstIcon="brightness_3"
+        />
         <ButtonRow>
           <MenuButton>
             <ListItemWithProgress
@@ -173,18 +185,34 @@ const GrailAreaInternal: FC<Props> = props => {
 
   function setThemeAndTitle() {
     let theme: IAppTheme = null;
+
+    let defaultThemeToSet = defaultTheme;
+    let ethThemeToSet = ethTheme;
+    let runewordThemeToSet = runewordTheme;
+
+    if (darkThemeIsEnabled()) {
+      defaultThemeToSet = defaultThemeDark;
+      ethThemeToSet = ethThemeDark;
+      runewordThemeToSet = runewordThemeDark;
+    }
+
     switch (grailMode) {
       case GrailMode.Eth:
-        theme = ethTheme;
+        theme = ethThemeToSet;
         break;
       case GrailMode.Runeword:
-        theme = runewordTheme;
+        theme = runewordThemeToSet;
         break;
       default:
-        break;
+        theme = defaultThemeToSet;
     }
 
     setAppTheme(theme);
+  }
+
+  function toggleDarkTheme() {
+    toggleDarkThemeEnabled();
+    setThemeAndTitle();
   }
 
   function onFilterResult(result: IFilterResult) {

--- a/client/src/areas/party/Party.tsx
+++ b/client/src/areas/party/Party.tsx
@@ -14,7 +14,7 @@ import { PartyButton } from "../../common/components/PartyButton";
 import { IPartyAreaRouterParams } from "../../RouteManager";
 import { IPartyUserData } from "../../common/definitions/union/IPartyUserData";
 import { PartyErrorHandler } from "./PartyErrorHandler";
-import { AppThemeContext, getPartyTheme } from "../../AppThemeContext";
+import { AppThemeContext, partyTheme } from "../../AppThemeContext";
 
 interface IPartyAreaState {
   data?: IPartyData;
@@ -50,7 +50,7 @@ const PartyAreaInternal: FC<Props> = props => {
       // so you can also use the app offline
       (err: IPartyError) => setState({ ...state, error: err })
     );
-    setAppTheme(getPartyTheme());
+    setAppTheme(partyTheme);
   }, []);
 
   if (state.error) {

--- a/client/src/areas/party/Party.tsx
+++ b/client/src/areas/party/Party.tsx
@@ -14,7 +14,7 @@ import { PartyButton } from "../../common/components/PartyButton";
 import { IPartyAreaRouterParams } from "../../RouteManager";
 import { IPartyUserData } from "../../common/definitions/union/IPartyUserData";
 import { PartyErrorHandler } from "./PartyErrorHandler";
-import { AppThemeContext, partyTheme } from "../../AppThemeContext";
+import { AppThemeContext, getPartyTheme } from "../../AppThemeContext";
 
 interface IPartyAreaState {
   data?: IPartyData;
@@ -50,7 +50,7 @@ const PartyAreaInternal: FC<Props> = props => {
       // so you can also use the app offline
       (err: IPartyError) => setState({ ...state, error: err })
     );
-    setAppTheme(partyTheme);
+    setAppTheme(getPartyTheme());
   }, []);
 
   if (state.error) {

--- a/client/src/areas/party/home/PartyHome.tsx
+++ b/client/src/areas/party/home/PartyHome.tsx
@@ -3,13 +3,13 @@ import { PartyLoginForm } from "./PartyLoginForm";
 import { PartyExplanation } from "./PartyExplanation";
 import { HomeButton } from "../../../common/components/HomeButton";
 import styled from "styled-components";
-import { partyTheme, AppThemeContext } from "../../../AppThemeContext";
+import { AppThemeContext, getPartyTheme } from "../../../AppThemeContext";
 import { FC, useEffect, useContext } from "react";
 
 export const PartyHome: FC = () => {
   const { setAppTheme } = useContext(AppThemeContext);
 
-  useEffect(() => setAppTheme(partyTheme), []);
+  useEffect(() => setAppTheme(getPartyTheme()), []);
 
   return (
     <div>

--- a/client/src/areas/party/home/PartyHome.tsx
+++ b/client/src/areas/party/home/PartyHome.tsx
@@ -3,13 +3,13 @@ import { PartyLoginForm } from "./PartyLoginForm";
 import { PartyExplanation } from "./PartyExplanation";
 import { HomeButton } from "../../../common/components/HomeButton";
 import styled from "styled-components";
-import { AppThemeContext, getPartyTheme } from "../../../AppThemeContext";
+import { AppThemeContext, partyTheme } from "../../../AppThemeContext";
 import { FC, useEffect, useContext } from "react";
 
 export const PartyHome: FC = () => {
   const { setAppTheme } = useContext(AppThemeContext);
 
-  useEffect(() => setAppTheme(getPartyTheme()), []);
+  useEffect(() => setAppTheme(partyTheme), []);
 
   return (
     <div>


### PR DESCRIPTION
This pull request will enable users to toggle the dark theme (default Material palette type of `dark`).

**NOTE:** This is my first time working with React, so there might be some amateur code smells... The additional themes in `AppThemeContext` looks like a DRY smell; perhaps you have an idea on how to make it better?

Let me know what you think! :smiley: 